### PR TITLE
New:Bump to v0.7.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,20 +96,15 @@ The output of the above commands.
 Changelog
 <<<<<<<<<
 
-v0.6.0
+v0.7.0
 ~~~~~~
 
-- 3fa0e29 Chg:Remove redundant code
-- 8e33efd Fix:Typo
-- d3552ac Fix:Release bad sdist. (closes #11)
-- e8eab43 New:Create CODE_OF_CONDUCT.md
-- 4d8dcd5 Chg:Better way to use codegen module
-- f85bd48 Chg:Raises AssertionError when the operator is not supported
-
-v0.6.1
-~~~~~~
-
-- c79ef49 Fix:jsonpath/lark_parser.py file is missing in wheel file
+- 46cfd08 Fix,Dev:make init_by_poetry error when python(system) version is
+  lower than 3.7
+- 19f981f Chg:Upgrade lark-parser
+- 982e344 New:Rewrite grammar to support more extensible jsonpath expression,
+  e.g., more elegant comparison syntax.
+- 1803339 New:Slice supports to cooperate with JSONPath.
 
 
 .. |license| image:: https://img.shields.io/github/license/linw1995/jsonpath.svg

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,20 +2,15 @@
 Changelog
 =========
 
-v0.6.0
+v0.7.0
 ~~~~~~
 
-- 3fa0e29 Chg:Remove redundant code
-- 8e33efd Fix:Typo
-- d3552ac Fix:Release bad sdist. (closes #11)
-- e8eab43 New:Create CODE_OF_CONDUCT.md
-- 4d8dcd5 Chg:Better way to use codegen module
-- f85bd48 Chg:Raises AssertionError when the operator is not supported
-
-v0.6.1
-~~~~~~
-
-- c79ef49 Fix:jsonpath/lark_parser.py file is missing in wheel file
+- 46cfd08 Fix,Dev:make init_by_poetry error when python(system) version is
+  lower than 3.7
+- 19f981f Chg:Upgrade lark-parser
+- 982e344 New:Rewrite grammar to support more extensible jsonpath expression,
+  e.g., more elegant comparison syntax.
+- 1803339 New:Slice supports to cooperate with JSONPath.
 
 .. include:: history.rst
     :start-line: 4

--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -2,6 +2,21 @@
 History
 =======
 
+v0.6.1
+~~~~~~
+
+- c79ef49 Fix:jsonpath/lark_parser.py file is missing in wheel file
+
+v0.6.0
+~~~~~~
+
+- 3fa0e29 Chg:Remove redundant code
+- 8e33efd Fix:Typo
+- d3552ac Fix:Release bad sdist. (closes #11)
+- e8eab43 New:Create CODE_OF_CONDUCT.md
+- 4d8dcd5 Chg:Better way to use codegen module
+- f85bd48 Chg:Raises AssertionError when the operator is not supported
+
 v0.5.1
 ~~~~~~
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jsonpath-extractor"
-version = "0.6.1"
+version = "0.7.0"
 license = "MIT"
 description = "A selector expression for extracting data from JSON."
 authors = ["林玮 <linw1995@icloud.com>"]


### PR DESCRIPTION
- 46cfd08 Fix,Dev:make init_by_poetry error when python(system) version is
  lower than 3.7
- 19f981f Chg:Upgrade lark-parser
- 982e344 New:Rewrite grammar to support more extensible jsonpath expression,
  e.g., more elegant comparison syntax.
- 1803339 New:Slice supports to cooperate with JSONPath.